### PR TITLE
Calling stop when listening cancels the recording

### DIFF
--- a/src/RecordingProcessor.js
+++ b/src/RecordingProcessor.js
@@ -303,7 +303,7 @@ function recordingProcessorEncapsulation() {
 				return;
 			}
 
-			if ( cancelRecord === true ) {
+			if ( cancelRecord === true || this._state == STATE.listening ) {
 				this._audioSamples = null;
 				this.port.postMessage({ message: 'canceled', reason: 'asked' });
 			}


### PR DESCRIPTION
Instead of returning the last 0.25s of audio.