### PR TITLE
Fix WAV file size field calculation

### DIFF
--- a/src/AudioRecord.js
+++ b/src/AudioRecord.js
@@ -155,7 +155,7 @@ class AudioRecord {
 		/* RIFF identifier */
 		AudioRecord.writeString(view, 0, 'RIFF');
 		/* file length */
-		view.setUint32(4, 32 + this.samples.length * 2, true);
+		view.setUint32(4, 36 + this.samples.length * 2, true);
 		/* RIFF type */
 		AudioRecord.writeString(view, 8, 'WAVE');
 		/* format chunk identifier */


### PR DESCRIPTION
Corrects this kind of error shown by MediaInfo:

```
Conformance errors                       : 2
 WAVE                                    : Yes
  data                                   : Yes
   General compliance                    : Element size 60928 is more than maximal permitted size 60924 (offset 0x2C)
 0x02000600                              : Yes
  General compliance                     : File size 60972 is less than expected size at least 60976 (offset 0xEE2C)
```